### PR TITLE
Add PagamentoListener, change atualizarStatusPedido signature

### DIFF
--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/http/PedidoApi.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/http/PedidoApi.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import br.com.fiap.soat.tech_challenge.fase4msproducao.api.http.requests.PedidoEmProducaoRequest;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,9 +44,10 @@ public class PedidoApi {
     }
 
     @Operation(summary = "Atualizar status do pedido", description = "Altera o status de um pedido identificado pelo seu id original.")
-    @PutMapping("/pedidos/{pedidoId}/{statusDoPedido}")
+    @PutMapping("/pedidos/{pedidoId}/{statusDoPedido}/{statusDoPagamento}")
     public ResponseEntity<PedidoPresenter> atualizarStatusPedido(@PathVariable UUID pedidoId,
-            @PathVariable StatusDoPedido statusDoPedido) {
-        return ResponseEntity.ok(pedidoController.atualizarStatusPedido(pedidoId, statusDoPedido));
+                                                                 @PathVariable StatusDoPedido statusDoPedido,
+                                                                 @PathVariable StatusDoPagamento statusDoPagamento) {
+        return ResponseEntity.ok(pedidoController.atualizarStatusPedido(pedidoId, statusDoPedido, statusDoPagamento));
     }
 }

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/PagamentoListener.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/PagamentoListener.java
@@ -1,0 +1,53 @@
+package br.com.fiap.soat.tech_challenge.fase4msproducao.api.sqs;
+
+import br.com.fiap.soat.tech_challenge.fase4msproducao.api.sqs.requests.PagamentoEvent;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPedido;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.interfaces.usecases.AtualizarStatusPedidoUseCasePort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+public class PagamentoListener {
+    private final Logger logger = LoggerFactory.getLogger(PagamentoListener.class);
+    private final ObjectMapper mapper;
+    private final AtualizarStatusPedidoUseCasePort atualizarStatusPedidoUseCase;
+
+    public PagamentoListener(ObjectMapper mapper, AtualizarStatusPedidoUseCasePort atualizarStatusPedidoUseCase) {
+        this.mapper = mapper;
+        this.atualizarStatusPedidoUseCase = atualizarStatusPedidoUseCase;
+    }
+
+    @SqsListener("${sqs.queues.pagamento-aprovado}")
+    public void receberEventoDePagamentoAprovado(String evento) throws JsonProcessingException {
+        logger.info("Processando evento de pagamento aprovado: {}", evento);
+        PagamentoEvent pagamentoAprovado = mapper.readValue(evento, PagamentoEvent.class);
+        atualizarStatus(pagamentoAprovado);
+    }
+
+    @SqsListener("${sqs.queues.pagamento-recusado}")
+    public void receberEventoDePagamentoRecusado(String evento) throws JsonProcessingException {
+        logger.info("Processando evento de pagamento recusado: {}", evento);
+        PagamentoEvent pagamentoRecusado = mapper.readValue(evento, PagamentoEvent.class);
+        atualizarStatus(pagamentoRecusado);
+    }
+
+    @Transactional
+    private void atualizarStatus(PagamentoEvent pagamento) {
+        StatusDoPagamento statusDoPagamento = StatusDoPagamento.valueOf(pagamento.getStatus());
+        if (statusDoPagamento.equals(StatusDoPagamento.APROVADO)) {
+            logger.info("Pagamento aprovado para o pedido {}", pagamento.getPedidoId());
+            atualizarStatusPedidoUseCase.execute(UUID.fromString(pagamento.getPedidoId()), StatusDoPedido.EM_PREPARACAO, statusDoPagamento);
+        } else {
+            logger.info("Pagamento recusado para o pedido {}", pagamento.getPedidoId());
+            atualizarStatusPedidoUseCase.execute(UUID.fromString(pagamento.getPedidoId()), StatusDoPedido.RECUSADO, statusDoPagamento);
+        }
+    }
+}

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/PedidoRecebidoListener.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/PedidoRecebidoListener.java
@@ -18,7 +18,7 @@ public class PedidoRecebidoListener {
         this.criarPedidoEmProducaoUseCasePort = criarPedidoEmProducaoUseCasePort;
     }
 
-    @SqsListener("${queue.name.pedido-recebido}")
+    @SqsListener("${sqs.queues.pedido-recebido}")
     public void obterPedido (PedidoRecebidoRequest pedidoRecebidoRequest) {
         try {
             logger.info("===============PEDIDO RECEBIDO COM SUCESSO===============> {}", pedidoRecebidoRequest);

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/requests/PagamentoEvent.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/requests/PagamentoEvent.java
@@ -1,0 +1,53 @@
+package br.com.fiap.soat.tech_challenge.fase4msproducao.api.sqs.requests;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+public class PagamentoEvent {
+    private String pagamentoId;
+    private String pedidoId;
+    private String clienteId;
+    private BigDecimal total;
+    private String status;
+
+    public String getPagamentoId() {
+        return pagamentoId;
+    }
+
+    public void setPagamentoId(String pagamentoId) {
+        this.pagamentoId = pagamentoId;
+    }
+
+    public String getPedidoId() {
+        return pedidoId;
+    }
+
+    public void setPedidoId(String pedidoId) {
+        this.pedidoId = pedidoId;
+    }
+
+    public String getClienteId() {
+        return clienteId;
+    }
+
+    public void setClienteId(String clienteId) {
+        this.clienteId = clienteId;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/controllers/PedidoController.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/controllers/PedidoController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.interfaces.usecases.CriarPedidoEmProducaoUseCasePort;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,8 +42,8 @@ public class PedidoController {
         return pedidos.stream().map(PedidoPresenter::fromDomain).collect(Collectors.toList());
     }
 
-    public PedidoPresenter atualizarStatusPedido(UUID pedidoId, StatusDoPedido statusDoPedido) {
-        Pedido pedido = atualizarStatusPedidoUseCase.execute(pedidoId, statusDoPedido);
+    public PedidoPresenter atualizarStatusPedido(UUID pedidoId, StatusDoPedido statusDoPedido, StatusDoPagamento statusDoPagamento) {
+        Pedido pedido = atualizarStatusPedidoUseCase.execute(pedidoId, statusDoPedido, statusDoPagamento);
         return PedidoPresenter.fromDomain(pedido);
     }
 

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/entities/StatusDoPedido.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/entities/StatusDoPedido.java
@@ -4,7 +4,7 @@ public enum StatusDoPedido {
     RECEBIDO {
         @Override
         public boolean podeAtualizarPara(StatusDoPedido statusDoPedido) {
-            return statusDoPedido.equals(EM_PREPARACAO);
+            return statusDoPedido.equals(EM_PREPARACAO) || statusDoPedido.equals(RECUSADO);
         }
     },
     EM_PREPARACAO {
@@ -20,6 +20,12 @@ public enum StatusDoPedido {
         }
     },
     FINALIZADO {
+        @Override
+        public boolean podeAtualizarPara(StatusDoPedido statusDoPedido) {
+            return false;
+        }
+    },
+    RECUSADO {
         @Override
         public boolean podeAtualizarPara(StatusDoPedido statusDoPedido) {
             return false;

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/interfaces/usecases/AtualizarStatusPedidoUseCasePort.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/interfaces/usecases/AtualizarStatusPedidoUseCasePort.java
@@ -3,8 +3,9 @@ package br.com.fiap.soat.tech_challenge.fase4msproducao.interfaces.usecases;
 import java.util.UUID;
 
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.Pedido;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPedido;
 
 public interface AtualizarStatusPedidoUseCasePort {
-    Pedido execute(UUID pedidoOriginalId, StatusDoPedido statusDoPedido);
+    Pedido execute(UUID pedidoOriginalId, StatusDoPedido statusDoPedido, StatusDoPagamento statusDoPagamento);
 }

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/jpa/entities/PedidoJpaEntity.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/jpa/entities/PedidoJpaEntity.java
@@ -9,13 +9,7 @@ import java.util.stream.Collectors;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.Pedido;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPedido;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "pedidos")
@@ -32,7 +26,7 @@ public class PedidoJpaEntity {
     private UUID pagamentoId;
     private LocalDateTime dataDeCriacao;
 
-    @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<ItemDoPedidoJpaEntity> itens;
 
     public UUID getId() {

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/presenters/PedidoPresenter.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/presenters/PedidoPresenter.java
@@ -4,12 +4,16 @@ package br.com.fiap.soat.tech_challenge.fase4msproducao.presenters;
 import java.util.UUID;
 
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.Pedido;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPedido;
 
 public class PedidoPresenter {
     private UUID id;
     private StatusDoPedido statusDoPedido;
     private UUID pedidoOriginalId;
+    private UUID clienteId;
+
+    private StatusDoPagamento statusDoPagamento;
 
     public UUID getId() {
         return id;
@@ -25,11 +29,21 @@ public class PedidoPresenter {
         pedidoPresenter.id = pedido.getId();
         pedidoPresenter.pedidoOriginalId = pedido.getPedidoOriginalId();
         pedidoPresenter.statusDoPedido = pedido.getStatusDoPedido();
+        pedidoPresenter.clienteId = pedido.getClienteId();
+        pedidoPresenter.statusDoPagamento = pedido.getStatusDoPagamento();
 
         return pedidoPresenter;
     }
 
     public UUID getPedidoOriginalId() {
         return pedidoOriginalId;
+    }
+
+    public UUID getClienteId() {
+        return clienteId;
+    }
+
+    public StatusDoPagamento getStatusDoPagamento() {
+        return statusDoPagamento;
     }
 }

--- a/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/usecases/AtualizarStatusPedidoUseCase.java
+++ b/src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/usecases/AtualizarStatusPedidoUseCase.java
@@ -21,7 +21,7 @@ public class AtualizarStatusPedidoUseCase implements AtualizarStatusPedidoUseCas
     }
 
     @Override
-    public Pedido execute(UUID pedidoOriginalId, StatusDoPedido statusDoPedido) {
+    public Pedido execute(UUID pedidoOriginalId, StatusDoPedido statusDoPedido, StatusDoPagamento statusDoPagamento) {
         var pedido = pedidoGateway.obterPedido(pedidoOriginalId);
 
         if (!pedido.getStatusDoPedido().podeAtualizarPara(statusDoPedido)) {
@@ -30,7 +30,7 @@ public class AtualizarStatusPedidoUseCase implements AtualizarStatusPedidoUseCas
         }
 
         pedido.setStatusDoPedido(statusDoPedido);
-        pedido.setStatusDoPagamento(StatusDoPagamento.APROVADO);
+        pedido.setStatusDoPagamento(statusDoPagamento);
         pedidoGateway.atualizarPedido(pedido);
         return pedido;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,9 @@ spring.jpa.show-sql=true
 
 server.port=8084
 
-queue.name.pedido-recebido=${QUEUE_PEDIDO_RECEBIDO:ms-producao-evento-pedido-recebido}
+sqs.queues.pedido-recebido=${QUEUE_PEDIDO_RECEBIDO:ms-producao-evento-pedido-recebido}
+sqs.queues.pagamento-aprovado=${QUEUE_PAGAMENTO_APROVADO:ms-producao-evento-pagamento-aprovado}
+sqs.queues.pagamento-recusado=${QUEUE_PAGAMENTO_RECUSADO:ms-producao-evento-pagamento-recusado}
 
 spring.cloud.aws.region.static=${AWS_REGION:us-east-1}
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY:localstack}

--- a/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/http/PedidoApiTest.java
+++ b/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/http/PedidoApiTest.java
@@ -1,12 +1,16 @@
 package br.com.fiap.soat.tech_challenge.fase4msproducao.api.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import br.com.fiap.soat.tech_challenge.fase4msproducao.api.http.PedidoApi;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPedido;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,8 +40,8 @@ class PedidoApiTest {
 
     @Test
     void atualizarStatusPedidoTest() {
-        when(pedidoController.atualizarStatusPedido(null, null)).thenReturn(null);
-        ResponseEntity<PedidoPresenter> response = pedidoApi.atualizarStatusPedido(null, null);
+        when(pedidoController.atualizarStatusPedido(any(), any(), any())).thenReturn(null);
+        ResponseEntity<PedidoPresenter> response = pedidoApi.atualizarStatusPedido(UUID.randomUUID(), StatusDoPedido.EM_PREPARACAO, StatusDoPagamento.APROVADO);
         assert response.getStatusCode().value() == 200;
     }
 }

--- a/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/controllers/PedidoControllerTest.java
+++ b/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/controllers/PedidoControllerTest.java
@@ -82,10 +82,10 @@ public class PedidoControllerTest {
         Pedido pedidoAtualizado = PedidoBuilder.build();
         pedidoAtualizado.setStatusDoPedido(StatusDoPedido.EM_PREPARACAO);
 
-        when(atualizarStatusPedidoUseCase.execute(pedidoId, StatusDoPedido.EM_PREPARACAO)).thenReturn(pedidoAtualizado);
+        when(atualizarStatusPedidoUseCase.execute(pedidoId, StatusDoPedido.EM_PREPARACAO, StatusDoPagamento.APROVADO)).thenReturn(pedidoAtualizado);
 
-        PedidoPresenter resultado = pedidoController.atualizarStatusPedido(pedidoId, StatusDoPedido.EM_PREPARACAO);
+        PedidoPresenter resultado = pedidoController.atualizarStatusPedido(pedidoId, StatusDoPedido.EM_PREPARACAO, StatusDoPagamento.APROVADO);
 
-        verify(atualizarStatusPedidoUseCase, times(1)).execute(pedidoId, StatusDoPedido.EM_PREPARACAO);
+        verify(atualizarStatusPedidoUseCase, times(1)).execute(pedidoId, StatusDoPedido.EM_PREPARACAO, StatusDoPagamento.APROVADO);
     }
 }

--- a/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/usescases/AtualizarStatusPedidoUseCaseTest.java
+++ b/src/test/java/br/com/fiap/soat/tech_challenge/fase4msproducao/usescases/AtualizarStatusPedidoUseCaseTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
+import br.com.fiap.soat.tech_challenge.fase4msproducao.entities.StatusDoPagamento;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,7 +46,7 @@ public class AtualizarStatusPedidoUseCaseTest {
         when(pedidoGatewayMock.obterPedido(pedidoOriginalId)).thenReturn(pedidoMock);
 
         AtualizarStatusPedidoUseCase atualizarStatusPedidoUseCase = new AtualizarStatusPedidoUseCase(pedidoGatewayMock);
-        Pedido pedidoAtualizado = atualizarStatusPedidoUseCase.execute(pedidoOriginalId, novoStatus);
+        Pedido pedidoAtualizado = atualizarStatusPedidoUseCase.execute(pedidoOriginalId, novoStatus, StatusDoPagamento.APROVADO);
 
         assertNotNull(novoStatus);
         verify(pedidoGatewayMock).atualizarPedido(pedidoAtualizado);
@@ -66,7 +67,7 @@ public class AtualizarStatusPedidoUseCaseTest {
 
         AtualizarStatusPedidoUseCase atualizarStatusPedidoUseCase = new AtualizarStatusPedidoUseCase(pedidoGatewayMock);
         assertThrows(StatusPedidoNaoAtualizadoException.class, () -> {
-            atualizarStatusPedidoUseCase.execute(pedidoOriginalId, novoStatus);
+            atualizarStatusPedidoUseCase.execute(pedidoOriginalId, novoStatus, StatusDoPagamento.APROVADO);
         });
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `fase4msproducao` project to handle payment status updates and improve the handling of order status updates. The most important changes include adding a new `PagamentoListener` class to process approved and rejected payment events, modifying the `PedidoApi` and `PedidoController` classes to handle the payment status in the `atualizarStatusPedido` method, and adding a new `RECUSADO` status to the `StatusDoPedido` enum.

**Changes to handle payment status updates:**

* [`src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/PagamentoListener.java`](diffhunk://#diff-a19dd460c68545f23cf58fdf0a504a4bec0005037d3c966ab9e115a1727e20b2R1-R53): Added a new `PagamentoListener` class to process approved and rejected payment events from Amazon SQS queues. The class uses the `AtualizarStatusPedidoUseCasePort` interface to update the status of the order based on the payment event.
* [`src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/sqs/requests/PagamentoEvent.java`](diffhunk://#diff-58bf4644d90fee687df2c0be7a64df9cd8af8487240d26bfa25810b322bb4c1dR1-R53): Added a new `PagamentoEvent` class to represent the payment event received from the Amazon SQS queue.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L11-R13): Added properties for the Amazon SQS queues that send approved and rejected payment events.

**Changes to handle order status updates:**

* [`src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/api/http/PedidoApi.java`](diffhunk://#diff-83735c788d19addd4ca7c71320c8cabb01881291c34906edb1ee5338e298c553L46-R51): Modified the `atualizarStatusPedido` method to handle the payment status. The method now takes an additional `StatusDoPagamento` parameter and passes it to the `PedidoController.atualizarStatusPedido` method.
* [`src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/controllers/PedidoController.java`](diffhunk://#diff-c52f96a7323e05099bb42c2467941e4434457e2126bd81c86c98773a0cd0d289L44-R46): Modified the `atualizarStatusPedido` method to handle the payment status. The method now takes an additional `StatusDoPagamento` parameter and passes it to the `AtualizarStatusPedidoUseCasePort.execute` method.

**Changes to order status:**

* [`src/main/java/br/com/fiap/soat/tech_challenge/fase4msproducao/entities/StatusDoPedido.java`](diffhunk://#diff-ad344ac140d8876c8047e0bc30ff3b3cd8587afea2f63d016a6003caf3a5ed7aL7-R7): Added a new `RECUSADO` status to the `StatusDoPedido` enum. The `podeAtualizarPara` method of the `RECEBIDO` status was also modified to allow updating to the `RECUSADO` status. [[1]](diffhunk://#diff-ad344ac140d8876c8047e0bc30ff3b3cd8587afea2f63d016a6003caf3a5ed7aL7-R7) [[2]](diffhunk://#diff-ad344ac140d8876c8047e0bc30ff3b3cd8587afea2f63d016a6003caf3a5ed7aR27-R32)